### PR TITLE
feat(settings): Implemented full-cycle 'Remove' remove profile picture button (Issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ This repository, including all its contents, sub-projects, modules, and componen
 
 This section documents the technical resolution for the first course assignment.
 
-### Getting Started Issue #1: Profile Picture Removal (Solved)
+### Issue #1: Profile Picture Removal (Solved)
 
-**Goal:** Implement a **"Remove Profile Picture"** button that clears the avatar and allows for immediate re-upload without page refresh.
+**Goal:** Implement a **"Remove"** button that clears the avatar and allows for immediate re-upload without page refresh.
 
 **Target File:** `gui/src/UI/Settings/UITabAccount.js`
 

--- a/README.md
+++ b/README.md
@@ -166,3 +166,19 @@ This repository, including all its contents, sub-projects, modules, and componen
 - [Ukrainian / Українська](https://github.com/HeyPuter/puter/blob/main/doc/i18n/README.ua.md)
 - [Urdu / اردو](https://github.com/HeyPuter/puter/blob/main/doc/i18n/README.ur.md)
 - [Vietnamese / Tiếng Việt](https://github.com/HeyPuter/puter/blob/main/doc/i18n/README.vi.md)
+
+## 📘 CodePath Setup & Troubleshooting Log
+
+This section documents the technical resolution for the first course assignment.
+
+### Getting Started Issue #1: Profile Picture Removal (Solved)
+
+**Goal:** Implement a **"Remove Profile Picture"** button that clears the avatar and allows for immediate re-upload without page refresh.
+
+**Target File:** `gui/src/UI/Settings/UITabAccount.js`
+
+| Bug Encountered | Technical Root Cause | Final Solution | 
+| :--- | :--- | :--- |
+| **Button Missing** | The button's HTML was conditionally excluded when no custom picture was set. | The button's wrapper (`<div class="remove-picture-wrapper">`) was **always rendered**, and its visibility (`display: none`) was controlled purely by inline CSS determined at render time. Button text was set to **"Remove"**. |
+| **UI Not Updating** | Profile picture remained visible after removal until a page refresh. | **Manual UI update** implemented: Cleared the `background-image` CSS property on the required DOM elements and reset it to the default icon path. |
+| **Stale Event Listener** | The cycle **Upload** → **Remove** → **Upload** failed because the click handler was not re-registering correctly after state change. | Implemented a helper function, **`attachProfilePictureHandler`**, using **`.off('click')`** to detach the old listener, followed by a **zero-delay `setTimeout`** wrapper in the removal handler to force a clean re-attachment in the browser's event loop. |

--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -39,6 +39,23 @@ export default {
             h += `</div>`;
         h += `</div>`;
 
+        // --- START NEW CODE BLOCK: REMOVE PICTURE BUTTON ---
+        const currentPicture = window.user?.profile?.picture;
+        const defaultIconPath = window.icons['profile.svg'];
+        
+        // Determine if the button should be hidden initially
+        // It should be hidden if the current picture is null/undefined OR if it's the default icon path.
+        const isCurrentlyDefault = !currentPicture || currentPicture === defaultIconPath;
+
+        // Set the initial inline style to hide the button if no custom picture is set
+        const initialDisplayStyle = isCurrentlyDefault ? 'display: none;' : '';
+
+        // Render the button's HTML, using the inline style for visibility
+        h += `<div class="remove-picture-wrapper" style="text-align: center; margin-top: -10px; margin-bottom: 20px; ${initialDisplayStyle}">`;
+            h += `<button class="button button-danger remove-profile-picture">${i18n('Remove') || 'Remove Profile Picture'}</button>`;
+        h += `</div>`;
+        // --- END NEW CODE BLOCK ---
+
         // change password button
         if(!window.user.is_temp){
             h += `<div class="settings-card">`;
@@ -134,21 +151,62 @@ export default {
             });
         });
 
-        $el_window.find('.change-profile-picture').on('click', async function (e) {
-            // open dialog
-            UIWindow({
-                path: '/' + window.user.username + '/Desktop',
-                // this is the uuid of the window to which this dialog will return
-                parent_uuid: $el_window.attr('data-element_uuid'),
-                allowed_file_types: ['.png', '.jpg', '.jpeg'],
-                show_maximize_button: false,
-                show_minimize_button: false,
-                title: 'Open',
-                is_dir: true,
-                is_openFileDialog: true,
-                selectable_body: false,
-            });    
-        })
+        // --- START NEW CODE BLOCK: REMOVE PICTURE HANDLER ---
+        $el_window.find('.remove-profile-picture').on('click', async function (e) {
+            e.preventDefault();
+            
+            try {
+                // 1. Send the API call to clear the profile picture field (set to null)
+                await update_profile(window.user.username, { picture: null });
+
+                // 2. Optimistically update the UI to show the default picture
+                const defaultIconUrl = window.icons['profile.svg'];
+                $el_window.find('.profile-picture').css('background-image', `url(${html_encode(defaultIconUrl)})`);
+                $('.profile-image').css('background-image', `url(${html_encode(defaultIconUrl)})`);
+                $('.profile-image').removeClass('profile-image-has-picture');
+                
+                $el_window.find('.remove-picture-wrapper').hide();
+                
+                // 🚩 Re-attach the click handler with a timeout to refresh the logic!
+                setTimeout(() => {
+                    attachProfilePictureHandler($el_window); // Give the browser a moment to detach the old handler
+                }, 0); 
+
+                alert('Profile picture removed successfully. UI updated.');
+                
+            } catch (error) {
+                    // If the network call itself failed (e.g., server down), show a real error
+                    console.error("Error removing profile picture:", error);
+                    alert('Connection Error: Could not reach the server to remove the picture.');
+                }
+        });
+        // --- END NEW CODE BLOCK ---
+        
+        // Helper function to attach the profile picture upload logic
+        const attachProfilePictureHandler = ($el_window) => {
+            // 1. Detach any existing click handler to prevent duplicates
+            $el_window.find('.change-profile-picture').off('click');
+            
+            // 2. Attach the click handler logic (THE ORIGINAL LOGIC IS MOVED HERE)
+            $el_window.find('.change-profile-picture').on('click', async function (e) {
+                UIWindow({
+                    path: '/' + window.user.username + '/Desktop',
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                    allowed_file_types: ['.png', '.jpg', '.jpeg'],
+                    show_maximize_button: false,
+                    show_minimize_button: false,
+                    title: 'Open',
+                    is_dir: true,
+                    is_openFileDialog: true,
+                    selectable_body: false,
+                });
+            });
+        }
+        
+        // -------------------------------------------------------------
+        // Call the function on initial load
+        // -------------------------------------------------------------
+        attachProfilePictureHandler($el_window); // This initializes the handler!
 
         $el_window.on('file_opened', async function(e){
             let selected_file = Array.isArray(e.detail) ? e.detail[0] : e.detail;
@@ -174,6 +232,10 @@ export default {
                     $('.profile-image').addClass('profile-image-has-picture');
                     // update profile picture
                     update_profile(window.user.username, {picture: base64data})
+                    
+                    // 🚩 NEW CODE: Manually show the button using the wrapper class
+                    $el_window.find('.remove-picture-wrapper').show();
+
                 }
             }
         })


### PR DESCRIPTION
This Pull Request addresses **Issue #1** by implementing the functionality to remove a user's custom profile picture and revert to the default avatar.

**Key features:**

    1. Added the "Remove" button to the Account Settings tab.

    2. Implemented API call to set picture: null.

    3. Fixed the UI bug where the picture and button did not update immediately upon removal.

    4. Resolved the stale event listener issue, allowing the user to **Upload → Remove → Upload** without needing a page refresh.

**Video Demonstration:** https://cap.so/s/sm85t8rp2gfc4t8