### PR TITLE
fix: Issue #2 - [BUG] Sidebar header text unreadable with certain theme lightness settings

### DIFF
--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -89,6 +89,8 @@ pre {
     --primary-lightness: 93.33%;
     --primary-alpha: 0.8;
     --primary-color: #373e44;
+    --primary-color-sidebar: #fefeff;
+    --primary-color-sidebar-item: #5a5d61aa;
 
     --window-head-hue: var(--primary-hue);
     --window-head-saturation: var(--primary-saturation);
@@ -101,6 +103,8 @@ pre {
     --window-sidebar-lightness: var(--primary-lightness);
     --window-sidebar-alpha: calc(min(1, 0.11 + var(--primary-alpha)));
     --window-sidebar-color: var(--primary-color);
+    --window-sidebar-active-bg: var(--primary-color-sidebar-item);
+    
 
     --taskbar-hue: var(--primary-hue);
     --taskbar-saturation: var(--primary-saturation);
@@ -1218,7 +1222,7 @@ span.header-sort-icon img {
     margin: 0;
     font-weight: bold;
     font-size: 13px;
-    color: #8f96a3;
+    color: var(--window-sidebar-color);
     text-shadow: 1px 1px rgb(247 247 247 / 15%);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -1243,7 +1247,7 @@ span.header-sort-icon img {
     margin-top: 2px;
     padding: 4px;
     border-radius: 3px;
-    color: #444444;
+    color: var(--window-sidebar-color);
     font-size: 13px;
     cursor: pointer;
     transition: 0.15s background-color;
@@ -1255,7 +1259,7 @@ span.header-sort-icon img {
 }
 
 .window-sidebar-item-active, .window-sidebar-item-drag-active, .window-sidebar-item-active:hover {
-    background-color: #fefeff;
+    background-color: var(--window-sidebar-active-bg);
 }
 
 .window-sidebar-item-placeholder {

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -104,6 +104,7 @@ pre {
     --window-sidebar-alpha: calc(min(1, 0.11 + var(--primary-alpha)));
     --window-sidebar-color: var(--primary-color);
     --window-sidebar-active-bg: var(--primary-color-sidebar-item);
+    --window-action-btn-filter: none;
     
 
     --taskbar-hue: var(--primary-hue);
@@ -1402,6 +1403,7 @@ span.header-sort-icon img {
     margin-right: 4px;
     margin-left: 4px;
     opacity: 0.5;
+    filter: var(--window-action-btn-filter);
     -webkit-user-drag: none;
     user-select: none;
     -moz-user-select: none;
@@ -1416,7 +1418,8 @@ span.header-sort-icon img {
 .window-scale-btn>img {
     width: 15px;
     height: 15px;
-    margin-top: 7px
+    margin-top: 7px;
+    filter: var(--window-action-btn-filter);
 }
 
 .window-app-iframe {

--- a/src/gui/src/services/ThemeService.js
+++ b/src/gui/src/services/ThemeService.js
@@ -121,6 +121,7 @@ export class ThemeService extends Service {
         this.root.style.setProperty('--primary-lightness', s.lig + '%');
         this.root.style.setProperty('--primary-alpha', s.alpha);
         this.root.style.setProperty('--primary-color', s.light_text ? 'white' : '#373e44');
+        this.root.style.setProperty('--primary-color-sidebar-item', s.light_text ? '#5a5d61aa' : '#fefeff');
 
         // TODO: Should we debounce this to reduce traffic?
         this.#broadcastService.sendBroadcast('themeChanged', {

--- a/src/gui/src/services/ThemeService.js
+++ b/src/gui/src/services/ThemeService.js
@@ -87,6 +87,9 @@ export class ThemeService extends Service {
                 ...data.colors,
             };
             this.reload_();
+        } else {
+            // Initialize CSS variables with default values
+            this.reload_();
         }
     }
 
@@ -122,6 +125,7 @@ export class ThemeService extends Service {
         this.root.style.setProperty('--primary-alpha', s.alpha);
         this.root.style.setProperty('--primary-color', s.light_text ? 'white' : '#373e44');
         this.root.style.setProperty('--primary-color-sidebar-item', s.light_text ? '#5a5d61aa' : '#fefeff');
+        this.root.style.setProperty('--window-action-btn-filter', s.light_text ? 'invert(1) brightness(2)' : 'none');
 
         // TODO: Should we debounce this to reduce traffic?
         this.#broadcastService.sendBroadcast('themeChanged', {

--- a/src/gui/src/services/ThemeService.js
+++ b/src/gui/src/services/ThemeService.js
@@ -86,11 +86,8 @@ export class ThemeService extends Service {
                 ...this.state,
                 ...data.colors,
             };
+        } 
             this.reload_();
-        } else {
-            // Initialize CSS variables with default values
-            this.reload_();
-        }
     }
 
     reset () {


### PR DESCRIPTION
## Description
This PR fixes sidebar text contrast issues in the `Explorer` when users adjust theme lightness settings. Sidebar header and item text colors are now dynamic and adapt to the current theme lightness, ensuring readability across all configurations.

## Before
- video: https://cap.link/11pjpg2ehn4j8x9
<img width="1917" height="943" alt="image" src="https://github.com/user-attachments/assets/8073801c-8bfa-4910-af6a-66b0379a8be9" />

## After
- video: https://cap.link/b7aftqpb07p8hdg
<img width="1918" height="946" alt="image" src="https://github.com/user-attachments/assets/506d8db2-c889-424b-8d26-42c37f116a28" />

## Implementation
- video: https://cap.link/125zrg257vdvhy6
<img width="1901" height="946" alt="image" src="https://github.com/user-attachments/assets/0f7123c3-6c34-4b8b-a73f-6aaae20e21ca" />

## Related Issue
Closes  [Issue #2 - [BUG] Sidebar header text unreadable with certain theme lightness settings ](https://github.com/codepath/puter/issues/6) #6

### Core Functionality
- Made sidebar title text color dynamic (adapts to theme lightness)
- Made sidebar item text color dynamic (adapts to theme lightness)
- Implemented adaptive background colors for active sidebar items
- Made window action button icons (minimize, maximize, close) dynamic
- Fixed CSS variables initialization on app startup

### CSS Variables
- Added `--primary-color-sidebar` variable for future extensibility
- Added `--primary-color-sidebar-item` variable for active item backgrounds
- Added `--window-sidebar-active-bg` variable to link active items to theme
- Added `--window-action-btn-filter` variable for window control buttons

### Theme Service
- Extended `reload_()` method to dynamically set colors based on lightness
- Fixed initialization bug where CSS variables weren't set on first load
- Uses existing `light_text` threshold (< 60) for consistency

## Implementation Details
- Text color switching: `light_text ? 'white' : '#373e44'`
- Active background switching: `light_text ? '#5a5d61aa' : '#fefeff'`
- Icon filter switching: `light_text ? 'invert(1) brightness(2)' : 'none'`
- Uses existing CSS variable infrastructure for consistency
- Threshold at lightness value 60 (consistent with existing theme logic)

## Testing Performed
- [x] Tested at lightness values: 0, 30, 60, 90, 100
- [x] Verified header readability across all lightness values
- [x] Verified sidebar items (Home, Documents, Public, Pictures, Videos) readability
- [x] Tested active item selection contrast on dark themes
- [x] Tested active item selection contrast on light themes
- [x] Verified window control buttons (minimize, maximize, close) visibility
- [x] Tested with both saved theme preferences and default state
- [x] Confirmed no visual regressions on other UI elements

## Files Modified
- `src/gui/src/css/style.css` - CSS variables and styling for sidebar and window controls
- `src/gui/src/services/ThemeService.js` - Dynamic color switching logic and initialization fix

