### PR TITLE
feat(start-menu): add context menu with pin/unpin for apps

### DIFF
--- a/src/backend/src/routers/update-taskbar-items.js
+++ b/src/backend/src/routers/update-taskbar-items.js
@@ -50,7 +50,7 @@ router.post('/update-taskbar-items', auth, express.json(), async (req, res, next
     await db.write(
         `UPDATE user SET taskbar_items = ? WHERE user.id = ?`,
         [
-            req.body.items ?? null,
+            JSON.stringify(req.body.items),
             req.user.id,
         ]
     )

--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -31,6 +31,7 @@ import UIWindowLogin from "./UIWindowLogin.js"
 import UIWindowQR from "./UIWindowQR.js"
 import UIWindowRefer from "./UIWindowRefer.js"
 import UITaskbar from "./UITaskbar.js"
+import UITaskbarItem from "./UITaskbarItem.js"
 import new_context_menu_item from "../helpers/new_context_menu_item.js"
 import refresh_item_container from "../helpers/refresh_item_container.js"
 import changeLanguage from "../i18n/i18nChangeLanguage.js"
@@ -1615,6 +1616,75 @@ $(document).on('click', '.start-app', async function(e){
     });
 })
 
+// Context menu for start menu apps
+$(document).on('contextmenu taphold', '.start-app', async function(e){
+    // dismiss taphold on regular devices
+    if(e.type === 'taphold' && !isMobile.phone && !isMobile.tablet)
+        return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Close any existing context menus first
+    $('.context-menu').remove();
+
+    // Get app information from data attributes
+    const app_name = $(this).attr('data-app-name');
+    const app_title = $(this).attr('data-app-title');
+    const app_icon = $(this).attr('data-app-icon');
+
+    // Check if app is pinned
+    const is_pinned = window.isAppPinned(app_name);
+
+    // Build context menu items
+    const menu_items = [];
+
+    // Open option
+    menu_items.push({
+        html: i18n('open'),
+        onClick: function(){
+            launch_app({
+                name: app_name
+            });
+            // close popovers
+            $(".popover").fadeOut(200, function(){
+                $(".popover").remove();
+            });
+        }
+    });
+
+    // Divider
+    menu_items.push('-');
+
+    // Pin/Unpin option
+    if(is_pinned){
+        menu_items.push({
+            html: i18n('remove_from_taskbar'),
+            onClick: function(){
+                window.unpinAppFromTaskbar(app_name);
+            }
+        });
+    } else {
+        menu_items.push({
+            html: i18n('keep_in_taskbar'),
+            onClick: function(){
+                window.pinAppToTaskbar({
+                    name: app_name,
+                    title: app_title,
+                    icon: app_icon
+                });
+            }
+        });
+    }
+
+    // Show context menu
+    UIContextMenu({
+        items: menu_items
+    });
+
+    return false;
+})
+
 $(document).on('click', '.user-options-login-btn', async function(e){
     const alert_resp = await UIAlert({
         message: `<strong>Save session before exiting!</strong><p>You are in a temporary session and logging into another account will erase all data in your current session.</p>`,
@@ -1747,6 +1817,90 @@ window.set_desktop_background = function(options){
     }
 }
 
+window.isAppPinned = function(appName){
+    // Check if the app exists in the user's pinned taskbar items
+    if(!window.user.taskbar_items || !Array.isArray(window.user.taskbar_items)){
+        return false;
+    }
+    return window.user.taskbar_items.some(item => item.name === appName);
+}
+
+window.pinAppToTaskbar = function(appInfo){
+    const app_name = appInfo.name;
+    
+    // Don't pin if already pinned
+    if(window.isAppPinned(app_name)){
+        return;
+    }
+
+    // Initialize taskbar_items if it doesn't exist
+    if(!window.user.taskbar_items){
+        window.user.taskbar_items = [];
+    }
+
+    // Add to user's taskbar items
+    window.user.taskbar_items.push({
+        name: app_name,
+        type: 'app'
+    });
+
+    // Create taskbar item if it doesn't already exist in the DOM
+    if($(`.taskbar-item[data-app="${app_name}"]`).length === 0){
+        UITaskbarItem({
+            icon: appInfo.icon,
+            app: app_name,
+            name: appInfo.title,
+            keep_in_taskbar: true,
+            before_trash: true,
+            onClick: function(){
+                let open_window_count = parseInt($(`.taskbar-item[data-app="${app_name}"]`).attr('data-open-windows'));
+                if(open_window_count === 0){
+                    launch_app({
+                        name: app_name,
+                    });
+                }else{
+                    return false;
+                }
+            }
+        });
+    } else {
+        // If item already exists in DOM, just mark it as pinned
+        $(`.taskbar-item[data-app="${app_name}"]`).attr('data-keep-in-taskbar', 'true');
+    }
+
+    // Persist to server
+    window.update_taskbar();
+}
+
+window.unpinAppFromTaskbar = function(appName){
+    // Don't unpin if not pinned
+    if(!window.isAppPinned(appName)){
+        return;
+    }
+
+    // Remove from user's taskbar items
+    if(window.user.taskbar_items){
+        window.user.taskbar_items = window.user.taskbar_items.filter(item => item.name !== appName);
+    }
+
+    // Find the taskbar item
+    const $taskbar_item = $(`.taskbar-item[data-app="${appName}"]`);
+    
+    if($taskbar_item.length > 0){
+        // Mark as not pinned
+        $taskbar_item.attr('data-keep-in-taskbar', 'false');
+        
+        // If no windows are open, remove the item from taskbar
+        const open_windows = parseInt($taskbar_item.attr('data-open-windows'));
+        if(open_windows === 0){
+            window.remove_taskbar_item($taskbar_item[0]);
+        }
+    }
+
+    // Persist to server
+    window.update_taskbar();
+}
+
 window.update_taskbar = function(){
     let items = []
     $('.taskbar-item-sortable[data-keep-in-taskbar="true"]').each(function(index){
@@ -1755,6 +1909,9 @@ window.update_taskbar = function(){
             type: 'app',
         })
     })
+
+    // Update the in-memory user taskbar items to match the DOM
+    window.user.taskbar_items = items;
 
     // update taskbar in the server-side
     $.ajax({


### PR DESCRIPTION
## Summary

Adds right-click context menu support for apps in the start menu, allowing users to launch apps and pin/unpin them to the taskbar directly from the start menu without needing to launch the app first.

## Problem

Previously, users could only pin apps to the taskbar by:
1. Launching the app first
2. Then right-clicking the app's taskbar item to pin it

This created unnecessary friction for users who wanted to organize their taskbar without launching apps.

## Solution

This PR adds a context menu to start menu apps that provides:
- **Open** option to launch the app
- **Keep in Taskbar** / **Remove from Taskbar** options based on current pin state
- Full pin/unpin functionality that persists across sessions
- Mobile support via long-press gesture

## Changes

### Frontend (`src/gui/src/UI/UIDesktop.js`)

- ✅ Added context menu event handler for `.start-app` elements (right-click/taphold)
- ✅ Implemented `isAppPinned()` helper function to check pinned state
- ✅ Implemented `pinAppToTaskbar()` function to add apps to taskbar
- ✅ Implemented `unpinAppFromTaskbar()` function to remove apps from taskbar
- ✅ Fixed state synchronization in `update_taskbar()` to keep in-memory state in sync with DOM
- ✅ Added `UITaskbarItem` import

### Backend (`src/backend/src/routers/update-taskbar-items.js`)

- ✅ Fixed database persistence by properly stringifying taskbar items array

## Technical Details

- Uses existing `UIContextMenu` component for consistency
- Follows same pin/unpin patterns as taskbar item context menus
- Closes existing context menus before opening new ones to prevent multiple menus
- Synchronizes `window.user.taskbar_items` with DOM state
- Handles edge cases (apps with open windows, already pinned apps, etc.)

## Testing

### Manual Testing Checklist

- [x] Right-click unpinned app shows "Open" and "Keep in Taskbar"
- [x] Right-click pinned app shows "Open" and "Remove from Taskbar"
- [x] Clicking "Keep in Taskbar" adds app to taskbar immediately
- [x] Clicking "Remove from Taskbar" removes app from taskbar (if no windows open)
- [x] Unpinning app with open windows keeps it in taskbar until windows close
- [x] Changes persist after page refresh
- [x] Only one context menu appears at a time
- [x] Context menu closes when clicking outside
- [x] Context menu closes when selecting "Open"
- [x] Long-press works on mobile devices

### Test Scenarios

1. **Pin from start menu**
   - Right-click unpinned app → Click "Keep in Taskbar"
   - ✅ App appears in taskbar immediately
   - ✅ Refresh page → App remains pinned

2. **Unpin from start menu (no windows)**
   - Right-click pinned app → Click "Remove from Taskbar"
   - ✅ App disappears from taskbar immediately
   - ✅ Refresh page → App remains unpinned

3. **Unpin with windows open**
   - Launch app → Right-click in start menu → Click "Remove from Taskbar"
   - ✅ App stays in taskbar (window is open)
   - ✅ Close window → App disappears from taskbar

4. **Multiple menus prevention**
   - Right-click app A → Right-click app B
   - ✅ First menu closes, second menu opens
