### PR TITLE
feat(ui): show hidden files count in status bar

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -557,6 +557,34 @@ async function UIDesktop(options){
             $(this).attr('data-path', new_el_path);
         });
 
+        // Update visibility based on whether the new name starts with '.'
+        const old_name = path.basename(item.old_path);
+        const old_is_hidden = old_name.startsWith('.');
+        const new_is_hidden = item.name.startsWith('.');
+        
+        // If hidden status changed, update the visibility classes
+        if(old_is_hidden !== new_is_hidden){
+            const all_matching_items = $(`.item[data-uid='${item.uid}']`);
+            
+            if(new_is_hidden){
+                // File is now hidden
+                all_matching_items.removeClass('item-visible');
+                if(window.user_preferences.show_hidden_files){
+                    all_matching_items.removeClass('item-hidden').addClass('item-revealed');
+                }else{
+                    all_matching_items.removeClass('item-revealed').addClass('item-hidden');
+                }
+            }else{
+                // File is now visible (not hidden)
+                all_matching_items.removeClass('item-hidden item-revealed').addClass('item-visible');
+            }
+            
+            // Update footer counts in all explorer windows
+            document.querySelectorAll('.window[data-app="explorer"]').forEach(el_window => {
+                window.update_explorer_footer_item_count(el_window);
+            });
+        }
+
         // Update all exact-matching windows
         $(`.window-${item.uid}`).each(function(){
             window.update_window_path(this, new_path);

--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -49,7 +49,17 @@ function UIItem(options){
 
     // set options defaults
     options.disabled = options.disabled ?? false;
-    options.visible = options.visible ?? 'visible'; // one of 'visible', 'revealed', 'hidden'
+    // Determine visibility based on filename if not explicitly provided
+    if(options.visible === undefined){
+        const is_hidden_file = options.name.startsWith('.');
+        if (!is_hidden_file){
+            options.visible = 'visible';
+        }else if (window.user_preferences.show_hidden_files) {
+            options.visible = 'revealed';
+        }else{
+            options.visible = 'hidden';
+        }
+    }
     options.is_dir = options.is_dir ?? false;
     options.is_selected = options.is_selected ?? false;
     options.is_shared = options.is_shared ?? false;

--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -3327,8 +3327,24 @@ window.scale_window = (el_window)=>{
 
 window.update_explorer_footer_item_count = function(el_window){
     //update dir count in explorer footer
-    let item_count = $(el_window).find('.item').length;
-    $(el_window).find('.explorer-footer .explorer-footer-item-count').html(item_count + ` ${i18n('item')}` + (item_count == 0 || item_count > 1 ? `${i18n('plural_suffix')}` : ''));
+    // Count all items (excluding hidden ones)
+    let all_items = $(el_window).find('.item');
+    let visible_items = all_items.filter(':not(.item-hidden)');
+    let item_count = visible_items.length;
+    
+    // Count hidden files that are currently revealed
+    let hidden_items = all_items.filter('.item-revealed');
+    let hidden_count = hidden_items.length;
+    
+    // Build the display text
+    let display_text = item_count + ` ${i18n('item')}` + (item_count == 0 || item_count > 1 ? `${i18n('plural_suffix')}` : '');
+    
+    // Add hidden count if hidden files are shown and there are hidden files
+    if(window.user_preferences.show_hidden_files && hidden_count > 0){
+        display_text += ` (${hidden_count} ${i18n('hidden')})`;
+    }
+    
+    $(el_window).find('.explorer-footer .explorer-footer-item-count').html(display_text);
 }
 
 window.update_explorer_footer_selected_items_count = function(el_window){

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -778,6 +778,11 @@ window.show_or_hide_files = (item_containers) => {
         .find('.item')
         .filter((_, item) => item.dataset.name.startsWith('.'))
         .removeClass(class_to_remove).addClass(class_to_add);
+    
+    // Update footer counts in all explorer windows
+    document.querySelectorAll('.window[data-app="explorer"]').forEach(el_window => {
+        window.update_explorer_footer_item_count(el_window);
+    });
 }
 
 window.create_folder = async(basedir, appendto_element)=>{
@@ -2351,6 +2356,33 @@ window.rename_file = async(options, new_name, old_name, old_path, el_item, el_it
             // Update `website_url`
             website_url = window.determine_website_url(new_path);
             $(el_item).attr('data-website_url', website_url);
+
+            // Update visibility based on whether the new name starts with '.'
+            const old_is_hidden = old_name.startsWith('.');
+            const new_is_hidden = new_name.startsWith('.');
+            
+            // If hidden status changed, update the visibility classes
+            if(old_is_hidden !== new_is_hidden){
+                const all_matching_items = $(`.item[data-uid='${$(el_item).attr('data-uid')}']`);
+                
+                if(new_is_hidden){
+                    // File is now hidden
+                    all_matching_items.removeClass('item-visible');
+                    if(window.user_preferences.show_hidden_files){
+                        all_matching_items.removeClass('item-hidden').addClass('item-revealed');
+                    }else{
+                        all_matching_items.removeClass('item-revealed').addClass('item-hidden');
+                    }
+                }else{
+                    // File is now visible (not hidden)
+                    all_matching_items.removeClass('item-hidden item-revealed').addClass('item-visible');
+                }
+                
+                // Update footer counts in all explorer windows
+                document.querySelectorAll('.window[data-app="explorer"]').forEach(el_window => {
+                    window.update_explorer_footer_item_count(el_window);
+                });
+            }
 
             // Update all exact-matching windows
             $(`.window-${options.uid}`).each(function(){

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -144,6 +144,7 @@ const en = {
         get_a_copy_of_on_puter: `Get a copy of '%%' on Puter.com!`,
         get_copy_link: 'Get Copy Link',
         hide_all_windows: "Hide All Windows",
+        hidden: 'hidden',
         home: 'Home',
         html_document: 'HTML document',
         hue: 'Hue',


### PR DESCRIPTION
## Summary

This PR implements a feature to display the count of hidden files in the explorer status bar footer. When "Show Hidden Files" is enabled and hidden files are present, the status bar shows the count in the format "X items (Y hidden)".

## Motivation

Currently, users cannot easily determine how many files in a folder are hidden files, even when "Show Hidden Files" is enabled. This information is useful for:
- Understanding folder contents at a glance
- Verifying that hidden files are being displayed correctly
- Managing files that start with '.' (dot prefix)

## Changes

### Core Functionality
- Modified `update_explorer_footer_item_count()` in UIWindow.js to count visible and hidden files separately
- Updated `show_or_hide_files()` in helpers.js to trigger footer count updates when toggling visibility
- Added "hidden" translation key to en.js for internationalization support

### Bug Fixes
- Fixed newly created hidden files defaulting to visible state instead of respecting user preferences
- Added visibility class updates when renaming files to/from hidden status (both local and remote operations)

### Files Modified
- `src/gui/src/UI/UIWindow.js` - Enhanced footer count logic
- `src/gui/src/helpers.js` - Added footer updates on toggle and rename operations
- `src/gui/src/UI/UIItem.js` - Auto-determine visibility based on filename
- `src/gui/src/UI/UIDesktop.js` - Handle visibility updates on remote rename events
- `src/gui/src/i18n/translations/en.js` - Added translation key

## Implementation Details

Hidden files are identified by names starting with '.' (dot). The visibility state uses three CSS classes:
- `item-visible`: Normal files (not hidden)
- `item-revealed`: Hidden files when "Show Hidden Files" is enabled (reduced opacity)
- `item-hidden`: Hidden files when "Show Hidden Files" is disabled (display: none)

The count only displays when:
1. "Show Hidden Files" preference is enabled
2. At least one hidden file is present in the current folder

## Testing Instructions

### Test Case 1: Basic Hidden File Count Display
1. Navigate to any folder (e.g., Documents)
2. Create 2 normal files: `file1.txt`, `file2.txt`
3. Create 2 hidden files: `.hidden1`, `.hidden2`
4. Verify status bar shows "2 items" (hidden files not counted when hidden)
5. Right-click and enable "Show Hidden Files"
6. Verify status bar shows "4 items (2 hidden)"
7. Disable "Show Hidden Files"
8. Verify status bar shows "2 items" again

### Test Case 2: Newly Created Hidden Files
1. Ensure "Show Hidden Files" is disabled
2. Create a new file and name it `.newhidden`
3. Verify the file does not appear (properly hidden)
4. Enable "Show Hidden Files"
5. Verify `.newhidden` appears with reduced opacity
6. Verify status bar shows hidden count

### Test Case 3: Renaming to/from Hidden
1. Enable "Show Hidden Files"
2. Create normal file: `test.txt`
3. Rename to `.test.txt`
4. Verify file becomes semi-transparent (revealed state)
5. Verify status bar updates hidden count
6. Rename back to `test.txt`
7. Verify file becomes fully visible
8. Verify status bar updates hidden count

### Test Case 4: Toggle Updates Count Immediately
1. Open folder with both normal and hidden files
2. Toggle "Show Hidden Files" on/off multiple times
3. Verify status bar updates immediately each time