### PR TITLE
feat(context-menu): add duplicate file functionality

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -1248,6 +1248,28 @@ function UIItem(options){
                 });
             }
             // -------------------------------------------
+            // Duplicate
+            // -------------------------------------------
+            if(!is_trashed && !is_trash && !options.is_dir){
+                menu_items.push({
+                    html: i18n('duplicate'),
+                    onClick: async function(){
+                        const source_path = $(el_item).attr('data-path');
+                        const dest_path = path.dirname(source_path);
+                        
+                        try {
+                            await puter.fs.copy({
+                                source: source_path,
+                                destination: dest_path,
+                                dedupeName: true,
+                            });
+                        } catch (err) {
+                            console.error('Duplicate failed:', err);
+                        }
+                    }
+                });
+            }
+            // -------------------------------------------
             // Paste Into Folder
             // -------------------------------------------
             if($(el_item).attr('data-is_dir') === '1' && !is_trashed && !is_trash){

--- a/src/gui/src/i18n/translations/ar.js
+++ b/src/gui/src/i18n/translations/ar.js
@@ -89,6 +89,7 @@ const ar = {
       credits: "الاعتمادات",
       current_password: "كلمة المرور الحالية",
       cut: "قص",
+      duplicate: "تكرار",
       clock: "ساعة",
       clock_visible_hide: "إخفاء - مخفية دائمًا",
       clock_visible_show: "إظهار - مرئية دائمًا",

--- a/src/gui/src/i18n/translations/bn.js
+++ b/src/gui/src/i18n/translations/bn.js
@@ -84,6 +84,7 @@ const bn = {
     credits: "ক্রেডিট",
     current_password: "বর্তমান পাসওয়ার্ড",
     cut: "কাটুন",
+    duplicate: "নকল",
     clock: "ঘড়ি",
     clock_visible_hide: "ঘড়ি লুকানো",
     clock_visible_show: "ঘড়ি দৃশ্যমান",

--- a/src/gui/src/i18n/translations/br.js
+++ b/src/gui/src/i18n/translations/br.js
@@ -85,6 +85,7 @@ const br = {
     credits: "Créditos",
     current_password: "Senha Atual",
     cut: 'Recortar',
+    duplicate: 'Duplicar',
     clock: "Relógio",
     clock_visible_hide: 'Ocultar - Sempre oculto',
     clock_visible_show: 'Mostrar - Sempre visível',

--- a/src/gui/src/i18n/translations/da.js
+++ b/src/gui/src/i18n/translations/da.js
@@ -84,6 +84,7 @@ const da = {
 		credits: 'Kreditter',
 		current_password: 'Nuværende adgangskode',
 		cut: 'Klip',
+		duplicate: 'Duplikér',
 		clock: 'Uret',
 		clock_visible_hide: 'Skjul - Altid skjult',
 		clock_visible_show: 'Vis - Altid synlig',

--- a/src/gui/src/i18n/translations/de.js
+++ b/src/gui/src/i18n/translations/de.js
@@ -84,6 +84,7 @@ const de = {
         credits: "Credits",
         current_password: "Aktuelles Passwort",
         cut: 'Ausschneiden',
+        duplicate: 'Duplizieren',
         clock: "Uhr",
         clock_visible_hide: 'Ausblenden - Immer ausgeblendet',
         clock_visible_show: 'Sichtbar - Immer sichtbar',

--- a/src/gui/src/i18n/translations/emoji.js
+++ b/src/gui/src/i18n/translations/emoji.js
@@ -56,6 +56,7 @@ const emoji = {
         create_shortcut: "📌🔄",
         current_password: "🔑🔍",
         cut: '✂️',
+        duplicate: '📋➕',
         date_modified: '📅🔄',
         delete: '🗑️',
         delete_permanently: "🗑️🔚",

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -87,6 +87,7 @@ const en = {
         credits: "Credits",
         current_password: "Current Password",
         cut: 'Cut',
+        duplicate: 'Duplicate',
         clock: "Clock",
         clock_visible_hide: 'Hide - Always hidden',
         clock_visible_show: 'Show - Always visible',

--- a/src/gui/src/i18n/translations/es.js
+++ b/src/gui/src/i18n/translations/es.js
@@ -101,6 +101,7 @@ const es = {
     credits: 'Creditos',
     current_password: 'Contraseña actual',
     cut: 'Cortar',
+    duplicate: 'Duplicar',
     clock: 'Reloj',
     clock_visible_hide: 'Ocultar - Siempre oculto',
     clock_visible_show: 'Mostrar - Siempre visible',

--- a/src/gui/src/i18n/translations/fa.js
+++ b/src/gui/src/i18n/translations/fa.js
@@ -56,6 +56,7 @@ const fa = {
     create_shortcut: "ایجاد میانبر",
     current_password: "رمز عبور فعلی",
     cut: "برش",
+    duplicate: "تکثیر",
     date_modified: "تاریخ تغییر",
     delete: "حذف",
     delete_permanently: "حذف دائمی",

--- a/src/gui/src/i18n/translations/fi.js
+++ b/src/gui/src/i18n/translations/fi.js
@@ -111,6 +111,7 @@ const fi = {
     credits: "Tekijät",
     current_password: "Nykyinen salasana",
     cut: "Leikkaa",
+    duplicate: "Monista",
     clock: "Kello",
     clock_visible_hide: "Piilota - aina piilossa",
     clock_visible_show: "Näytä - aina näkyvissä",

--- a/src/gui/src/i18n/translations/fr.js
+++ b/src/gui/src/i18n/translations/fr.js
@@ -84,6 +84,7 @@ const fr = {
         credits: "Crédits",
         current_password: "Mot de passe actuel",
         cut: 'Couper',
+        duplicate: 'Dupliquer',
         clock: "Horloge",
         clock_visible_hide: 'Cacher - Toujours cachée',
         clock_visible_show: 'Afficher - Toujours visible',

--- a/src/gui/src/i18n/translations/he.js
+++ b/src/gui/src/i18n/translations/he.js
@@ -90,6 +90,7 @@ const en = {
     credits: "הערכה",
     current_password: "סיסמה נוכחית",
     cut: "גזירה",
+    duplicate: "שכפול",
     clock: "שעון",
     clock_visible_hide: "הסתר - תמיד מוסתר",
     clock_visible_show: "הצג - תמיד מוצג",

--- a/src/gui/src/i18n/translations/hi.js
+++ b/src/gui/src/i18n/translations/hi.js
@@ -84,6 +84,7 @@ const hi = {
         credits: "क्रेडिट",
         current_password: "वर्तमान पासवर्ड",
         cut: 'काटना',
+        duplicate: 'डुप्लिकेट',
         clock: "घड़ी",
         clock_visible_hide: 'छुपना - हमेशा छिपा रहना',
         clock_visible_show: 'दिखाएँ - सदैव दृश्यमान',

--- a/src/gui/src/i18n/translations/hu.js
+++ b/src/gui/src/i18n/translations/hu.js
@@ -80,6 +80,7 @@ const hu = {
         credits: "Kreditek",
         current_password: "Jelenlegi jelszó",
         cut: "Kivágás",
+        duplicate: "Másolat készítése",
         clock: "Óra",
         clock_visible_hide: "Elrejt - Mindig rejtett",
         clock_visible_show: "Megjelenít - Mindig látható",

--- a/src/gui/src/i18n/translations/hy.js
+++ b/src/gui/src/i18n/translations/hy.js
@@ -84,6 +84,7 @@ const hy = {
         credits: "Կրեդիտներ",
         current_password: "Ընթացիկ գաղտնաբառ",
         cut: "Կտրել",
+        duplicate: "Կրկնօրինակել",
         clock: "Ժամացույց",
         clock_visible_hide: "Թաքցնել - Միշտ թաքնված",
         clock_visible_show: "Ցուցադրել - Միշտ տեսանելի",

--- a/src/gui/src/i18n/translations/id.js
+++ b/src/gui/src/i18n/translations/id.js
@@ -91,6 +91,7 @@ const id = {
     credits: "Kredit",
     current_password: "Kata Sandi Saat Ini",
     cut: "Potong",
+    duplicate: "Duplikat",
     clock: "Jam",
     clock_visible_hide: "Sembunyikan - Selalu tersembunyi",
     clock_visible_show: "Tampilkan - Selalu terlihat",

--- a/src/gui/src/i18n/translations/ig.js
+++ b/src/gui/src/i18n/translations/ig.js
@@ -92,6 +92,7 @@ const ig = {
     credits: "Ebe e si nweta",
     current_password: "paswọọdụ Ugbu a",
     cut: "Bee",
+    duplicate: "Mee oyiri",
     clock: "Elekere",
     clock_visible_hide: "Ezo - ezoro ezo mgbe niile",
     clock_visible_show: "Gosi - A na-ahụ ya mgbe niile",

--- a/src/gui/src/i18n/translations/it.js
+++ b/src/gui/src/i18n/translations/it.js
@@ -93,6 +93,7 @@ const it = {
     credits: "Crediti",
     current_password: "Password attuale",
     cut: "Taglia",
+    duplicate: "Duplica",
     clock: "Orologio",
     clock_visible_hide: "Nascondi - Sempre nascosto",
     clock_visible_show: "Mostra - Sempre visibile",

--- a/src/gui/src/i18n/translations/ja.js
+++ b/src/gui/src/i18n/translations/ja.js
@@ -85,6 +85,7 @@ const ja = {
         credits: "クレジット",
         current_password: "現在のパスワード",
         cut: 'カット',
+        duplicate: '複製',
         clock: "時計",
         clock_visible_hide: '非表示 - 常に非表示',
         clock_visible_show: '表示 - 常に表示',

--- a/src/gui/src/i18n/translations/ko.js
+++ b/src/gui/src/i18n/translations/ko.js
@@ -93,6 +93,7 @@ const ko = {
     credits: "크레딧",
     current_password: "현재 비밀번호",
     cut: "잘라내기",
+    duplicate: "복제",
     clock: "시계",
     clock_visible_hide: "숨기기 - 항상 숨김",
     clock_visible_show: "표시 - 항상 표시",

--- a/src/gui/src/i18n/translations/ku.js
+++ b/src/gui/src/i18n/translations/ku.js
@@ -95,6 +95,7 @@ const ku = {
     credits: "بڕگەکان",
     current_password: "وشەی تێپەڕی ئێستا",
     cut: "برین",
+    duplicate: "دووبارەکردنەوە",
     clock: "کاژێر",
     clock_visible_hide: "شاردنەوە - هەمیشە شاردراوە",
     clock_visible_show: "پیشان - هەمیشە پیشاندراوە",

--- a/src/gui/src/i18n/translations/nb.js
+++ b/src/gui/src/i18n/translations/nb.js
@@ -56,6 +56,7 @@ const nb = {
         create_shortcut: "Opprett snarvei",
         current_password: "Nåværende passord",
         cut: "Klipp ut",
+        duplicate: "Dupliser",
         date_modified: "Endret dato",
         delete: "Slett",
         delete_permanently: "Slett permanent",

--- a/src/gui/src/i18n/translations/nl.js
+++ b/src/gui/src/i18n/translations/nl.js
@@ -84,6 +84,7 @@ const nl = {
 		credits: 'Credits',
 		current_password: 'Huidig Wachtwoord',
 		cut: 'Knippen',
+		duplicate: 'Dupliceren',
 		clock: 'Klok',
 		clock_visible_hide: 'Verbergen - Altijd verborgen',
 		clock_visible_show: 'Weergeven - Altijd zichtbaar',

--- a/src/gui/src/i18n/translations/nn.js
+++ b/src/gui/src/i18n/translations/nn.js
@@ -51,6 +51,7 @@ const nn = {
         create_shortcut: "Opprett snarveg",
         current_password: "Noeverande passord",
         cut: "Klipp ut",
+        duplicate: "Dupliser",
         date_modified: "Endra dato",
         delete: "Slett",
         delete_permanently: "Slett permanent",

--- a/src/gui/src/i18n/translations/pl.js
+++ b/src/gui/src/i18n/translations/pl.js
@@ -84,6 +84,7 @@ const pl = {
         credits: "Licencje",
         current_password: "Aktualne hasło",
         cut: 'Wytnij',
+        duplicate: 'Duplikuj',
         clock: "Zegar",
         clock_visible_hide: 'Ukryj - zawsze ukryty',
         clock_visible_show: 'Pokaż - zawsze widoczny',

--- a/src/gui/src/i18n/translations/pt.js
+++ b/src/gui/src/i18n/translations/pt.js
@@ -86,6 +86,7 @@ const pt = {
         credits: "Créditos",
         current_password: "Password Atual",
         cut: 'Cortar',
+        duplicate: 'Duplicar',
         clock: 'Relógio',
         clock_visible_hide: 'Esconder - Sempre escondido',
         clock_visible_show: 'Mostrar - Sempre visível',

--- a/src/gui/src/i18n/translations/ro.js
+++ b/src/gui/src/i18n/translations/ro.js
@@ -85,6 +85,7 @@ const ro = {
         credits: "Credite",
         current_password: "Parola Curentă",
         cut: 'Decupează',
+        duplicate: 'Duplică',
         clock: "Ora",
         clock_visible_hide: "Ascunde - Întotdeauna ascuns",
         clock_visible_show: "Afișează - Întotdeauna vizibil",

--- a/src/gui/src/i18n/translations/ru.js
+++ b/src/gui/src/i18n/translations/ru.js
@@ -93,6 +93,7 @@ const ru = {
     credits: 'Авторы',
     current_password: 'Текущий пароль',
     cut: 'Вырезать',
+    duplicate: 'Дублировать',
     clock: 'Часы',
     clock_visible_hide: 'Скрыть - Всегда скрыто',
     clock_visible_show: 'Показать - Всегда на виду',

--- a/src/gui/src/i18n/translations/sv.js
+++ b/src/gui/src/i18n/translations/sv.js
@@ -85,6 +85,7 @@ const sv = {
         credits: "Tack",
         current_password: "Nuvarande lösenord",
         cut: "Klipp ut",
+        duplicate: "Duplicera",
         clock: "Klocka",
         clock_visible_hide: "Dölj - Alltid dold",
         clock_visible_show: "Visa - Alltid synlig",

--- a/src/gui/src/i18n/translations/ta.js
+++ b/src/gui/src/i18n/translations/ta.js
@@ -83,6 +83,7 @@ const ta = {
         credits: "கடன்கள்",
         current_password: "தற்போதைய கடவுச்சொல்",
         cut: 'வெட்டு',
+        duplicate: 'நகல் எடு',
         clock: "கடிகாரம்",
         clock_visible_hide: 'மறை - எப்போதும் மறைந்திருக்கும்',
         clock_visible_show: 'காட்டு - எப்போதும் தெரியும்',

--- a/src/gui/src/i18n/translations/th.js
+++ b/src/gui/src/i18n/translations/th.js
@@ -83,6 +83,7 @@ const th = {
         credits: "Credits",
         current_password: "รหัสผ่านปัจจุบัน",
         cut: "ตัด",
+        duplicate: "ทำซ้ำ",
         clock: "นาฬิกา",
         clock_visible_hide: 'ซ่อน - ซ่อนตลอด',
         clock_visible_show: 'แสดง - แสดงตลอด',

--- a/src/gui/src/i18n/translations/tr.js
+++ b/src/gui/src/i18n/translations/tr.js
@@ -84,6 +84,7 @@ const tr = {
         credits: "Katkıda Bulunanlar",
         current_password: "Mevcut Parola",
         cut: "Kes",
+        duplicate: "Çoğalt",
         clock: "Saat",
         clock_visible_hide: "Gizle - Daima gizli",
         clock_visible_show: "Göster - Daima görünür",

--- a/src/gui/src/i18n/translations/ua.js
+++ b/src/gui/src/i18n/translations/ua.js
@@ -86,6 +86,7 @@ const ua = {
         credits: "Титри",
         current_password: "Поточний Пароль",
         cut: "Вирізати",
+        duplicate: "Дублювати",
         clock: "Годинник",
         clock_visible_hide: "Приховати - Завжди приховано",
         clock_visible_show: "Показати - Завжди на виду",

--- a/src/gui/src/i18n/translations/ur.js
+++ b/src/gui/src/i18n/translations/ur.js
@@ -89,6 +89,7 @@ const ur = {
     credits: "کریڈٹس",
     current_password: "موجودہ پاس ورڈ",
     cut: "کاٹیں",
+    duplicate: "نقل بنائیں",
     clock: "گھڑی",
     clock_visible_hide: "چھپائیں - ہمیشہ پوشیدہ",
     clock_visible_show: "دکھائیں - ہمیشہ دکھائی دیں۔",

--- a/src/gui/src/i18n/translations/vi.js
+++ b/src/gui/src/i18n/translations/vi.js
@@ -85,6 +85,7 @@ const vi = {
         credits: "Tín dụng",
         current_password: "Mật khẩu hiện tại",
         cut: 'Cắt',
+        duplicate: 'Nhân đôi',
         clock: "Đồng hồ",
         clock_visible_hide: 'Ẩn - Luôn ẩn',
         clock_visible_show: 'Hiện - Luôn hiển thị',

--- a/src/gui/src/i18n/translations/zh.js
+++ b/src/gui/src/i18n/translations/zh.js
@@ -85,6 +85,7 @@ const zh = {
         credits: "特别鸣谢",
         current_password: "当前密码",
         cut: '剪切',
+        duplicate: '复制副本',
         clock: "时间",
         clock_visible_hide: '隐藏 - 始终隐藏',
         clock_visible_show: '显示 - 始终显示',

--- a/src/gui/src/i18n/translations/zhtw.js
+++ b/src/gui/src/i18n/translations/zhtw.js
@@ -84,6 +84,7 @@ const zhtw = {
         credits: "製作群",
         current_password: "目前密碼",
         cut: '剪下',
+        duplicate: '複製副本',
         clock: "時鐘",
         clock_visible_hide: '隱藏 - 始終隱藏',
         clock_visible_show: '顯示 - 始終可見',


### PR DESCRIPTION
### Description

This PR adds a "Duplicate" option to the file context menu, allowing users to create a copy of a file in the same directory with automatic name deduplication.

### Problem Statement

Currently, users must manually use Copy (Ctrl+C) and Paste (Ctrl+V) to duplicate files, which doesn't automatically generate unique filenames. This creates friction in the user workflow and requires manual renaming to avoid conflicts.

### Solution

Added a "Duplicate" menu item to the file context menu that:
- Creates a copy of the selected file in the same directory
- Automatically generates unique filenames using sequential numbering
- Only appears for files (not directories)
- Is excluded from trash/trashed items

### Changes Made

#### Frontend Changes
- **src/gui/src/UI/UIItem.js**: Added duplicate menu item with onClick handler (lines 1250-1271)
- **src/gui/src/i18n/translations/*.js**: Added 'duplicate' translation key to all 37 language files

#### Technical Implementation
- Uses existing `puter.fs.copy()` API with `dedupeName: true` parameter
- Leverages backend's automatic filename deduplication logic
- Follows existing naming pattern: `filename (1).ext`, `filename (2).ext`, etc.
- Includes error handling with console logging

### Testing

#### Manual Testing Performed
- Basic file duplication creates `filename (1).ext`
- Sequential duplicates create `filename (2).ext`, `filename (3).ext`, etc.
- Works with various file types: .txt, .html, .png, .zip
- Handles complex filenames: spaces, multiple extensions, no extensions
- Correctly hidden for directories
- Correctly hidden in trash

#### Test Cases
1. Right-click file → "Duplicate" appears in menu
2. Click "Duplicate" → new file appears with unique name
3. Duplicate again → sequential number increments
4. Right-click folder → "Duplicate" does not appear
5. Right-click file in trash → "Duplicate" does not appear