### PR TITLE
feat: add opt-in window title from filename for apps

### DIFF
--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -578,6 +578,12 @@ function generate_edit_app_section(app) {
                     <input type="checkbox" id="edit-app-maximize-on-start" name="edit-app-maximize-on-start" value="true" style="margin-top:30px;" ${maximize_on_start ? 'checked' : ''} ${app.background ? 'disabled' : ''}>
                     <label for="edit-app-maximize-on-start" style="display: inline;">Maximize window on start</label>
                 </div>
+
+                <div style="margin-top:30px;">
+                    <input type="checkbox" id="edit-app-use-file-name-as-title" name="edit-app-use-file-name-as-title" value="true" ${app.metadata?.use_file_name_as_window_title ? 'checked' : ''}>
+                    <label for="edit-app-use-file-name-as-title" style="display: inline;">Automatically set window title to opened file's name</label>
+                    <p>When enabled, opening a file will display the file's name in the window title instead of the app name.</p>
+                </div>
                 
                 <div>
                     <label for="edit-app-window-width">Initial window width</label>
@@ -651,7 +657,8 @@ function trackOriginalValues(){
             hideTitleBar: $('#edit-app-hide-titlebar').is(':checked'),
             locked: $('#edit-app-locked').is(':checked'),
             credentialless: $('#edit-app-credentialless').is(':checked'),
-            fullPageOnLanding: $('#edit-app-fullpage-on-landing').is(':checked')
+            fullPageOnLanding: $('#edit-app-fullpage-on-landing').is(':checked'),
+            useFileNameAsTitle: $('#edit-app-use-file-name-as-title').is(':checked')
         }
     };
 }
@@ -688,7 +695,8 @@ function hasChanges() {
         $('#edit-app-hide-titlebar').is(':checked') !== originalValues.checkboxes.hideTitleBar ||
         $('#edit-app-locked').is(':checked') !== originalValues.checkboxes.locked ||
         $('#edit-app-credentialless').is(':checked') !== originalValues.checkboxes.credentialless ||
-        $('#edit-app-fullpage-on-landing').is(':checked') !== originalValues.checkboxes.fullPageOnLanding
+        $('#edit-app-fullpage-on-landing').is(':checked') !== originalValues.checkboxes.fullPageOnLanding ||
+        $('#edit-app-use-file-name-as-title').is(':checked') !== originalValues.checkboxes.useFileNameAsTitle
     );
 }
 
@@ -729,6 +737,7 @@ function resetToOriginalValues() {
     $('#edit-app-locked').prop('checked', originalValues.checkboxes.locked);
     $('#edit-app-credentialless').prop('checked', originalValues.checkboxes.credentialless);
     $('#edit-app-fullpage-on-landing').prop('checked', originalValues.checkboxes.fullPageOnLanding);
+    $('#edit-app-use-file-name-as-title').prop('checked', originalValues.checkboxes.useFileNameAsTitle);
 
     if (originalValues.icon) {
         $('#edit-app-icon').css('background-image', `url(${originalValues.icon})`);
@@ -1237,6 +1246,7 @@ $(document).on('click', '.edit-app-save-btn', async function (e) {
             hide_titlebar: $('#edit-app-hide-titlebar').is(":checked"),
             locked: $(`#edit-app-locked`).is(":checked") ?? false,
             credentialless: $(`#edit-app-credentialless`).is(":checked") ?? true,
+            use_file_name_as_window_title: $('#edit-app-use-file-name-as-title').is(":checked"),
 
         },
         filetypeAssociations: filetype_associations,

--- a/src/gui/src/helpers/launch_app.js
+++ b/src/gui/src/helpers/launch_app.js
@@ -67,7 +67,10 @@ const launch_app = async (options)=>{
     //-----------------------------------
     // title
     //-----------------------------------
-    if(app_info.title)
+    // If the app setting is enabled and a file is being opened, use the file name as the title
+    if(options.window_title && app_info.metadata?.use_file_name_as_window_title && options.file_path)
+        title = options.window_title;
+    else if(app_info.title)
         title = app_info.title;
     else if(options.window_title)
         title = options.window_title;


### PR DESCRIPTION
## Summary

Adds a developer-configurable setting to automatically set window titles to opened file names instead of app names, improving multi-file workflow usability.

## Problem

When users open multiple files of the same type (e.g., multiple PDF documents or spreadsheets) in Puter, all windows display the same generic application name as their title. This makes it difficult to distinguish between windows and navigate between different open files, creating a poor user experience when working with multiple documents simultaneously.

Application developers currently have no way to configure their apps to use file names as window titles, forcing users to click into each window to identify which file is open.

## Solution

This PR implements an opt-in checkbox in the Developer Center that allows app developers to enable automatic window title setting based on opened file names.

### Key Features

- New checkbox setting in Dev Center app configuration
- Stored in app metadata as `use_file_name_as_window_title`
- Fully integrated with existing form tracking system
- Window title determination logic updated to respect the setting
- Backward compatible - disabled by default

## Changes

### Frontend (Dev Center)

**File**: `src/dev-center/js/dev-center.js`

- Added checkbox UI in Window settings section (line 583)
- Integrated with `trackOriginalValues()` function (line 661)
- Added to `hasChanges()` detection logic (line 699)
- Included in `resetToOriginalValues()` function (line 740)
- Added to save handler metadata object (line 1249)

### Backend Logic

**File**: `src/gui/src/helpers/launch_app.js`

- Updated title determination logic (lines 70-78)
- Checks metadata flag before setting window title
- Prefers filename when setting enabled and file is being opened

## Technical Details

### Window Title Logic

if (options.window_title && 
    app_info.metadata?.use_file_name_as_window_title && 
    options.file_path)
{
    title = options.window_title;
}
else if (app_info.title) {
    title = app_info.title;
}The logic checks three conditions:
1. A window title is provided (the filename)
2. The app has the setting enabled in metadata
3. A file is being opened (not just launching the app)

### Form Tracking Integration

The checkbox follows the existing pattern used by other settings:
- Initial state tracked on page load
- Changes detected for Save/Reset button states
- Reset functionality restores original value
- All states properly serialized to metadata