### PR TITLE
fix: prevent window focus when clicking close/minimize buttons

### DIFF
--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -1225,6 +1225,10 @@ window.initgui = async function(options){
         if($(e.target).hasClass('taskbar') || $(e.target).closest('.taskbar').length > 0)
             return;
 
+        // if close or minimize button clicked, don't activate window
+        if($(e.target).closest('.window-close-btn, .window-minimize-btn').length > 0)
+            return;
+
         // if mouse is clicked on a window, activate it
         if(window.mouseover_window !== undefined){
             // if popover clicked on, don't activate window. This is because if an app 


### PR DESCRIPTION
## Problem

When users click the close (X) or minimize button on a background window, the window is brought to the foreground before the action executes. This creates a jarring user experience where windows "jump" to the front, disrupting the user's visual context and making the interface feel unresponsive to their intent.

### Steps to Reproduce

1. Open two or more windows in the application, ensuring they overlap
2. Position the windows so that one window partially covers another
3. Click the close button (X) or minimize button on the window that is behind/underneath
4. Observe: The background window jumps to the foreground first, then closes or minimizes

### Expected Behavior

When a user clicks the close or minimize button on a window, the window should execute the requested action without first being brought to the foreground or changing focus. The current window focus and z-order should remain unchanged.

## Solution

Added an early return check in the global mousedown event handler for window activation when the click target is a close or minimize button. This prevents `focusWindow()` from being called on these buttons while still allowing the button's click handler to execute normally.

## Changes

### Modified Files

- `src/gui/src/initgui.js` (lines 1228-1230)

### Technical Details

The fix adds a check using jQuery's `.closest()` method to detect if the mousedown event occurred on a close or minimize button (or any child element of these buttons). If detected, the handler returns early before calling `focusWindow()`.

```javascript
// if close or minimize button clicked, don't activate window
if($(e.target).closest('.window-close-btn, .window-minimize-btn').length > 0)
    return;
```

This follows the existing pattern already used in the codebase for excluding taskbar and popover clicks from window activation.

## Testing

### Manual Testing Performed

- Verified close button on background window closes without bringing to foreground
- Verified minimize button on background window minimizes without bringing to foreground
- Verified clicking window title bar still brings window to foreground (unchanged behavior)
- Verified clicking window body/content area still brings window to foreground (unchanged behavior)
- Tested with 3-4 overlapping windows in various positions
- Tested with maximized, normal-sized, and partially obscured windows

### Acceptance Criteria

- [x] Clicking the close button on a background window closes it without bringing it to the foreground first
- [x] Clicking the minimize button on a background window minimizes it without bringing it to the foreground first
- [x] Clicking other parts of a window (title bar, content area) still brings the window to the foreground as expected
- [x] The fix works consistently across different window states and configurations
- [x] No regression in other window management behaviors

## Impact

### Benefits

- Improved user experience with more intuitive window management
- Reduced visual disruption when closing or minimizing background windows
- More predictable behavior aligned with user expectations

### Risk Assessment

- Low risk: The change is minimal (3 lines) and surgical
- Follows existing code patterns in the same file
- Only affects close/minimize button behavior
- All other window interactions remain unchanged

## Additional Notes

This fix addresses a common UX complaint in windowed interfaces and brings the behavior in line with standard operating system window managers.

